### PR TITLE
feat: 시간 범위 유효성 검사 추가 및 오류 메시지 표시

### DIFF
--- a/src/features/study/components/StudyForm.tsx
+++ b/src/features/study/components/StudyForm.tsx
@@ -83,7 +83,9 @@ export default function StudyForm({
                 />
               </svg>
               <p className="text-xs text-gray-400">클릭하여 이미지 업로드</p>
-              <p className="text-xs text-gray-300 mt-1">JPG, PNG, GIF (최대 5MB)</p>
+              <p className="text-xs text-gray-300 mt-1">
+                JPG, PNG, GIF (최대 5MB)
+              </p>
             </>
           )}
         </div>
@@ -325,6 +327,9 @@ export default function StudyForm({
             )}
           </div>
         </div>
+        {errors.timeRange && (
+          <p className="text-xs text-red-500">{errors.timeRange}</p>
+        )}
       </section>
 
       {/* 주제 & 난이도 */}

--- a/src/features/study/hooks/useStudyForm.ts
+++ b/src/features/study/hooks/useStudyForm.ts
@@ -1,10 +1,6 @@
 import { useState, useCallback, useRef } from "react";
 import type { ChangeEvent, KeyboardEvent, FormEvent } from "react";
-import type {
-  StudyFormState,
-  StudyFormErrors,
-  StudyDay,
-} from "@/types/study";
+import type { StudyFormState, StudyFormErrors, StudyDay } from "@/types/study";
 
 const INITIAL_STATE: StudyFormState = {
   thumbnail: null,
@@ -44,6 +40,9 @@ function validateForm(state: StudyFormState): StudyFormErrors {
   if (state.durationWeeks === "") errors.durationWeeks = "기간을 입력해주세요.";
   if (!state.startTime) errors.startTime = "시작 시간을 선택해주세요.";
   if (!state.endTime) errors.endTime = "종료 시간을 선택해주세요.";
+  if (state.startTime && state.endTime && state.startTime >= state.endTime) {
+    errors.timeRange = "종료 시간은 시작 시간보다 늦어야 합니다.";
+  }
   if (!state.subject) errors.subject = "주제를 선택해주세요.";
   if (!state.difficulty) errors.difficulty = "난이도를 선택해주세요.";
   if (state.tags.length === 0) errors.tags = "태그를 1개 이상 입력해주세요.";
@@ -66,6 +65,7 @@ function isFormValid(state: StudyFormState): boolean {
   if (state.durationWeeks === "") return false;
   if (!state.startTime) return false;
   if (!state.endTime) return false;
+  if (state.startTime >= state.endTime) return false;
   if (!state.subject) return false;
   if (!state.difficulty) return false;
   if (state.tags.length === 0) return false;
@@ -155,7 +155,10 @@ export function useStudyForm(onSubmit?: (state: StudyFormState) => void) {
     const trimmed = tagInput.trim();
     if (!trimmed) return;
     if (form.tags.includes(trimmed)) return;
-    setForm((prev: StudyFormState) => ({ ...prev, tags: [...prev.tags, trimmed] }));
+    setForm((prev: StudyFormState) => ({
+      ...prev,
+      tags: [...prev.tags, trimmed],
+    }));
     setTagInput("");
     setErrors((prev: StudyFormErrors) => {
       const next = { ...prev };
@@ -166,7 +169,10 @@ export function useStudyForm(onSubmit?: (state: StudyFormState) => void) {
   }, [tagInput, form.tags]);
 
   const handleRemoveTag = useCallback((tag: string) => {
-    setForm((prev: StudyFormState) => ({ ...prev, tags: prev.tags.filter((t: string) => t !== tag) }));
+    setForm((prev: StudyFormState) => ({
+      ...prev,
+      tags: prev.tags.filter((t: string) => t !== tag),
+    }));
     setIsDirty(true);
   }, []);
 

--- a/src/types/study.d.ts
+++ b/src/types/study.d.ts
@@ -34,6 +34,7 @@ export interface StudyFormErrors {
   durationWeeks?: string;
   startTime?: string;
   endTime?: string;
+  timeRange?: string;
   subject?: string;
   difficulty?: string;
   tags?: string;


### PR DESCRIPTION
## **관련 이슈**
- #16 

## 작업내용
- useStudyForm.ts 폼 상태 및 검증 로직 구현
StudyFormState 전체 필드 초기값 및 useState 관리
validateForm() — 필수값 누락, 시간 역전(startTime >= endTime), 태그 개수 초과, 모집 인원 범위(3~99) 검증
isFormValid() — 실시간 CTA 버튼 활성화 여부 판단 (제출 시도 없이도 즉시 반영)
핸들러 전체 구현: updateField, handleThumbnailChange, handleDayToggle, handleAddTag, handleRemoveTag, handleTagInputKeyDown, handleSubmit, handleReset
태그 최대 5개 제한은 handleAddTag 내 early return으로 처리

- StudyForm.tsx 필수 입력 UI 전체 구현
썸네일 업로드 영역 + 클릭 시 파일 선택, 미리보기 즉시 반영
스터디 제목(textarea, 80자 카운터), 스터디 유형 라디오, 지역 select(오프라인 선택 시 노출)
모집 인원 숫자 입력(3~99), 스터디 요일 토글 버튼
시작일 date picker, 기간 select(1주16주), 시간 범위(시작종료)
스터디 주제 칩 선택(8종), 난이도 버튼(초/중/고)
태그 텍스트 입력 + Enter/추가 버튼, 선택 태그 삭제

- 검증 동작 확인
모든 필수값 충족 시 CTA 버튼 활성화
종료 시간이 시작 시간보다 이를 경우 timeRange 에러 표시
오프라인 선택 시 지역 미선택이면 제출 불가 및 에러 표시
