### PR TITLE
feat: 로그인 API 연동 및 JWT 토큰 처리 로직 구현

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -1,0 +1,19 @@
+import { axiosInstance } from './axios';
+
+// 백엔드로 보낼 데이터 타입
+export interface LoginRequest {
+    email: string;
+    password: string;
+}
+
+// 백엔드에서 받을 데이터 타입 (토큰)
+export interface LoginResponse {
+    accessToken: string;
+    refreshToken: string;
+    // user 정보 등 추가
+}
+
+export const loginApi = async (data: LoginRequest): Promise<LoginResponse> => {
+    const response = await axiosInstance.post<LoginResponse>('/accounts/login/', data);
+    return response.data;
+};

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -16,13 +16,25 @@ export const axiosInstance = axios.create({
 // Request Interceptor (요청 보내기 전)
 axiosInstance.interceptors.request.use(
     (config) => {
-        // 스토리지에서 access_token 꺼냄
-        const token = storage.getAccessToken();
-        
-        // 토큰이 있다면, 모든 요청의 Authorization 헤더에 Bearer 토큰을 꽂아줌
-        if (token) {
-        config.headers.Authorization = `Bearer ${token}`;
+        // 토큰을 헤더에 넣지 말아야 할 API 엔드포인트 목록
+        // (로그인, 회원가입, 토큰 갱신 등은 Access Token이 필요 없음)
+        const noAuthUrls = [
+            '/accounts/login/',
+            '/accounts/token/refresh/',
+            // 나중에 '/accounts/register/', '/accounts/password-reset/' 등 추가 예정
+        ];
+
+        // 현재 요청하려는 URL이 위 목록에 포함되어 있는지 확인
+        const isNoAuthUrl = noAuthUrls.some((url) => config.url?.includes(url));
+
+        // 예외 목록에 없는 일반 API 요청일 때만 토큰 꽂아줌
+        if (!isNoAuthUrl) {
+            const token = storage.getAccessToken();
+            if (token) {
+                config.headers.Authorization = `Bearer ${token}`;
+            }
         }
+        
         return config;
     },
     (error) => Promise.reject(error)

--- a/src/features/auth/components/LoginForm.tsx
+++ b/src/features/auth/components/LoginForm.tsx
@@ -1,6 +1,6 @@
-// src/features/auth/components/LoginForm.tsx
 import { useState } from 'react';
 import { validateEmail, validatePassword } from '../utils/authValidators';
+import { useLogin } from '../hooks/useLogin';
 
 export default function LoginForm() {
     const [email, setEmail] = useState('');
@@ -8,16 +8,18 @@ export default function LoginForm() {
     const [emailError, setEmailError] = useState('');
     const [passwordError, setPasswordError] = useState('');
 
+    const { login, isLoading, apiError } = useLogin();
+
     const handleEmailChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         const value = e.target.value;
         setEmail(value);
         
         if (value.length === 0) {
-        setEmailError('');
+            setEmailError('');
         } else if (!validateEmail(value)) {
-        setEmailError('이메일을 확인해 주세요.');
+            setEmailError('이메일을 확인해 주세요.');
         } else {
-        setEmailError('');
+            setEmailError('');
         }
     };
 
@@ -26,73 +28,74 @@ export default function LoginForm() {
         setPassword(value);
         
         if (value.length === 0) {
-        setPasswordError('');
+            setPasswordError('');
         } else if (!validatePassword(value)) {
-        setPasswordError('비밀번호를 확인해 주세요.');
+            setPasswordError('비밀번호를 확인해 주세요.');
         } else {
-        setPasswordError('');
+            setPasswordError('');
         }
     };
 
     const isValid = validateEmail(email) && validatePassword(password);
 
-    const handleSubmit = (e: React.FormEvent) => {
+    const handleSubmit = async (e: React.FormEvent) => {
         e.preventDefault();
-        if (isValid) {
-        console.log('로그인 시도:', { email, password });
+        if (isValid && !isLoading) {
+            await login(email, password);
         }
     };
 
     return (
-        // 💡 폼 전체 간격과 너비 설정 (기존 코드 반영)
         <form onSubmit={handleSubmit} className="w-full max-w-[322px] flex flex-col gap-3">
         
-        {/* 이메일 입력 영역 */}
-        <div>
-            <input
-            type="email"
-            placeholder="이메일"
-            value={email}
-            onChange={handleEmailChange}
-            // 💡 기존 스타일 유지 + 에러 상태에 따라 테두리 색상만 변경!
-            className={`w-full max-w-[322px] border-b-2 py-3 text-base placeholder:text-gray-500 focus:outline-none transition-colors ${
-                emailError 
-                ? 'border-error' 
-                : 'border-gray-300 focus:border-primary'
-            }`}
-            />
-            {emailError && <p className="text-error text-[13px] mt-[6px]">{emailError}</p>}
-        </div>
+            {/* 이메일 입력 영역 */}
+            <div>
+                <input
+                type="email"
+                placeholder="이메일"
+                value={email}
+                onChange={handleEmailChange}
+                className={`w-full max-w-[322px] border-b-2 py-3 text-base placeholder:text-gray-500 focus:outline-none transition-colors ${
+                    emailError 
+                    ? 'border-error' 
+                    : 'border-gray-300 focus:border-primary'
+                }`}
+                />
+                {emailError && <p className="text-error text-[13px] mt-[6px]">{emailError}</p>}
+            </div>
 
-        {/* 비밀번호 입력 영역 */}
-        <div className="mb-2"> {/* 💡 기존 input에 있던 mb-2를 에러메시지 공간 확보를 위해 wrapper로 이동 */}
-            <input
-            type="password"
-            placeholder="비밀번호"
-            value={password}
-            onChange={handlePasswordChange}
-            className={`w-full max-w-[322px] border-b-2 py-3 text-base placeholder:text-gray-500 focus:outline-none transition-colors ${
-                passwordError 
-                ? 'border-error' 
-                : 'border-gray-300 focus:border-primary'
-            }`}
-            />
-            {passwordError && <p className="text-error text-[13px] mt-[6px]">{passwordError}</p>}
-        </div>
+            {/* 비밀번호 입력 영역 */}
+            <div className="mb-2"> 
+                <input
+                type="password"
+                placeholder="비밀번호"
+                value={password}
+                onChange={handlePasswordChange}
+                className={`w-full max-w-[322px] border-b-2 py-3 text-base placeholder:text-gray-500 focus:outline-none transition-colors ${
+                    passwordError 
+                    ? 'border-error' 
+                    : 'border-gray-300 focus:border-primary'
+                }`}
+                />
+                {passwordError && <p className="text-error text-[13px] mt-[6px]">{passwordError}</p>}
+            </div>
 
-        {/* 로그인 버튼 */}
-        <button
-            type="submit"
-            disabled={!isValid}
-            // 💡 기존 스타일(rounded-lg, py-4) 유지 + 활성/비활성 색상 분기 처리
-            className={`w-full max-w-[322px] font-bold text-lg py-4 rounded-lg transition-colors ${
-            isValid 
-                ? 'bg-primary text-background hover:bg-primary-light cursor-pointer' 
-                : 'bg-gray-300 text-background cursor-not-allowed'
-            }`}
-        >
-            로그인
-        </button>
+            {apiError && (
+                <p className="text-error text-[13px] text-center mb-2">{apiError}</p>
+            )}
+
+            {/* 로그인 버튼 */}
+            <button
+                type="submit"
+                disabled={!isValid || isLoading}
+                className={`w-full max-w-[322px] font-bold text-lg py-4 rounded-lg transition-colors ${
+                    isValid && !isLoading
+                        ? 'bg-primary text-background hover:bg-primary-light cursor-pointer' 
+                        : 'bg-gray-300 text-background cursor-not-allowed'
+                }`}
+            >
+                {isLoading ? '로그인 중...' : '로그인'}
+            </button>
         </form>
     );
 }

--- a/src/features/auth/hooks/useLogin.ts
+++ b/src/features/auth/hooks/useLogin.ts
@@ -1,0 +1,36 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { loginApi } from '@/api/auth';
+import { storage } from '@/utils/storage'; 
+
+export const useLogin = () => {
+    const navigate = useNavigate();
+    const [isLoading, setIsLoading] = useState(false);
+    const [apiError, setApiError] = useState<string | null>(null);
+
+    const login = async (email: string, password: string) => {
+        setIsLoading(true);
+        setApiError(null); // 에러 초기화
+
+        try {
+        // API 호출
+        const data = await loginApi({ email, password });
+
+        // 스토리지에 토큰 저장
+        storage.setAccessToken(data.accessToken);
+        storage.setRefreshToken(data.refreshToken);
+
+        // 성공 시 메인 페이지로 이동
+        navigate('/');
+        
+        } catch (error: any) {
+            // 실패 시 에러 핸들링
+            const errorMessage = error.response?.data?.error || '로그인에 실패했습니다. 다시 시도해주세요.';
+            setApiError(errorMessage);
+        } finally {
+            setIsLoading(false); 
+        }
+    };
+
+    return { login, isLoading, apiError };
+};


### PR DESCRIPTION
## 관련 이슈
#36 

## 작업 내용
로그인 API 연동 (src/api/auth.ts): axiosInstance를 활용하여 백엔드 로그인 엔드포인트(POST /accounts/login/)와 통신하는 함수를 구현했습니다.
비즈니스 로직 캡슐화 (useLogin 훅): API 호출, 로딩 상태(isLoading), 서버 에러 메시지(apiError), 성공 시 메인 페이지(/) 리다이렉트 처리를 커스텀 훅으로 분리했습니다.
JWT 토큰 저장: 로그인 성공 시 응답으로 받은 access_token과 refresh_token을 스토리지 유틸리티를 통해 로컬 스토리지에 안전하게 보관하도록 구현했습니다.
Axios Request Interceptor 예외 처리: 스토리지에 만료된 토큰이 남아있을 경우 로그인 요청 시 401 에러가 발생하는 버그를 방지하기 위해, 로그인/토큰 갱신 등의 특정 URL에는 토큰을 헤더에 담지 않도록 예외 로직(noAuthUrls)을 추가했습니다.

UI 상태 반영 (LoginForm.tsx)
  - useLogin 훅을 연결하여 실제 로그인 Submit 이벤트를 연동했습니다.
  - 로그인 실패 시 서버에서 전달받은 에러 메시지를 버튼 상단에 노출하도록 처리했습니다.
  - 통신 중(Loading)에는 버튼 텍스트를 '로그인 중...'으로 변경하고 다중 클릭을 방지(disabled)했습니다.

스크린샷 (선택)

https://github.com/user-attachments/assets/926d86b0-9d04-42f1-8667-e625fbba4173


https://github.com/user-attachments/assets/5c3c98c3-d738-4849-8f60-3f699f603423

